### PR TITLE
Add pkg-config to macOS dependencies

### DIFF
--- a/build/README.osx
+++ b/build/README.osx
@@ -9,8 +9,13 @@ You must have Xcode installed, with the command-line build tools (an
 optional component).
 
 You must have libsndfile (http://www.mega-nerd.com/libsndfile/)
-installed in order to build the command-line host successfully.  But
-you do not need libsndfile if you only want to build plugins.
+and pkg-config installed in order to build the command-line host
+successfully.  But you do not need libsndfile if you only want to
+build plugins.
+
+To install dependencies with Homebrew:
+
+ $ brew install pkg-config libsndfile
 
 
 Building at the command line


### PR DESCRIPTION
Just tried to install on a vanilla macOS install, and discovered that pkg-config must also be installed for libsndfile to be detected correctly. Amended the README accordingly.