### PR TITLE
Check if '-ldl' is needed in vamp-hostsdk.pc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -279,6 +279,7 @@ clean:
 distclean:	clean
 		rm -f $(SDK_STATIC) $(SDK_DYNAMIC) $(HOSTSDK_STATIC) $(HOSTSDK_DYNAMIC) $(PLUGIN_TARGET) $(HOST_TARGET) $(RDFGEN_TARGET) *~ */*~
 		rm -f config.log config.status Makefile
+		rm -f $(PCDIR)/*.pc
 
 install:	$(SDK_STATIC) $(SDK_DYNAMIC) $(HOSTSDK_STATIC) $(HOSTSDK_DYNAMIC) $(PLUGIN_TARGET) $(HOST_TARGET) $(RDFGEN_TARGET)
 		mkdir -p $(DESTDIR)$(INSTALL_API_HEADERS)
@@ -308,12 +309,9 @@ install:	$(SDK_STATIC) $(SDK_DYNAMIC) $(HOSTSDK_STATIC) $(HOSTSDK_DYNAMIC) $(PLU
 		ln -s $(INSTALL_SDK_LIBNAME) $(DESTDIR)$(INSTALL_SDK_LIBS)/$(INSTALL_SDK_LINK_DEV)
 		rm -f $(DESTDIR)$(INSTALL_SDK_LIBS)/$(INSTALL_HOSTSDK_LINK_DEV)
 		ln -s $(INSTALL_HOSTSDK_LIBNAME) $(DESTDIR)$(INSTALL_SDK_LIBS)/$(INSTALL_HOSTSDK_LINK_DEV)
-		sed "s,%PREFIX%,$(INSTALL_PREFIX)," $(PCDIR)/vamp.pc.in \
-		> $(DESTDIR)$(INSTALL_PKGCONFIG)/vamp.pc
-		sed "s,%PREFIX%,$(INSTALL_PREFIX)," $(PCDIR)/vamp-sdk.pc.in \
-		> $(DESTDIR)$(INSTALL_PKGCONFIG)/vamp-sdk.pc
-		sed "s,%PREFIX%,$(INSTALL_PREFIX)," $(PCDIR)/vamp-hostsdk.pc.in \
-		> $(DESTDIR)$(INSTALL_PKGCONFIG)/vamp-hostsdk.pc
+		cp $(PCDIR)/vamp.pc $(DESTDIR)$(INSTALL_PKGCONFIG)/vamp.pc
+		cp $(PCDIR)/vamp-sdk.pc $(DESTDIR)$(INSTALL_PKGCONFIG)/vamp-sdk.pc
+		cp $(PCDIR)/vamp-hostsdk.pc $(DESTDIR)$(INSTALL_PKGCONFIG)/vamp-hostsdk.pc
 		sed -e "s,%LIBNAME%,$(INSTALL_SDK_LIBNAME),g" \
 		    -e "s,%LINK_ABI%,$(INSTALL_SDK_LINK_ABI),g" \
 		    -e "s,%LINK_DEV%,$(INSTALL_SDK_LINK_DEV),g" \

--- a/configure
+++ b/configure
@@ -630,6 +630,7 @@ SNDFILE_CFLAGS
 PKG_CONFIG_LIBDIR
 PKG_CONFIG_PATH
 PKG_CONFIG
+LDL
 EGREP
 GREP
 CPP
@@ -3732,6 +3733,8 @@ if test "$ac_res" != no; then :
 
 fi
 
+LDL=$LIBS
+
 
 # Check whether --enable-programs was given.
 if test "${enable_programs+set}" = set; then :
@@ -3958,6 +3961,9 @@ if test "x$GCC" = "xyes"; then
   esac
   CXXFLAGS="$CXXFLAGS -std=c++98"
 fi
+
+ac_config_files="$ac_config_files pkgconfig/vamp.pc pkgconfig/vamp-sdk.pc pkgconfig/vamp-hostsdk.pc"
+
 
 
 
@@ -4669,6 +4675,9 @@ cat >>$CONFIG_STATUS <<\_ACEOF || ac_write_fail=1
 for ac_config_target in $ac_config_targets
 do
   case $ac_config_target in
+    "pkgconfig/vamp.pc") CONFIG_FILES="$CONFIG_FILES pkgconfig/vamp.pc" ;;
+    "pkgconfig/vamp-sdk.pc") CONFIG_FILES="$CONFIG_FILES pkgconfig/vamp-sdk.pc" ;;
+    "pkgconfig/vamp-hostsdk.pc") CONFIG_FILES="$CONFIG_FILES pkgconfig/vamp-hostsdk.pc" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,8 @@ if pkg-config --modversion vamp-sdk >/dev/null 2>&1; then
 fi
 
 AC_SEARCH_LIBS([dlopen],[dl])
+LDL=$LIBS
+AC_SUBST(LDL)
 
 dnl See if the user wants to build programs, or just the SDK
 AC_ARG_ENABLE(programs,	[AS_HELP_STRING([--enable-programs],
@@ -53,6 +55,8 @@ if test "x$GCC" = "xyes"; then
   CXXFLAGS="$CXXFLAGS -std=c++98"
 fi
 changequote([,])dnl
+
+AC_CONFIG_FILES([pkgconfig/vamp.pc pkgconfig/vamp-sdk.pc pkgconfig/vamp-hostsdk.pc])
 
 AC_SUBST(CXXFLAGS)
 AC_SUBST(CFLAGS)

--- a/pkgconfig/vamp-hostsdk.pc.in
+++ b/pkgconfig/vamp-hostsdk.pc.in
@@ -1,4 +1,4 @@
-prefix=%PREFIX%
+prefix=@prefix@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
@@ -6,5 +6,5 @@ includedir=${prefix}/include
 Name: vamp-hostsdk
 Version: 2.8
 Description: Development library for Vamp audio analysis plugin hosts
-Libs: -L${libdir} -lvamp-hostsdk -ldl
+Libs: -L${libdir} -lvamp-hostsdk @LDL@
 Cflags: -I${includedir} 

--- a/pkgconfig/vamp-sdk.pc.in
+++ b/pkgconfig/vamp-sdk.pc.in
@@ -1,4 +1,4 @@
-prefix=%PREFIX%
+prefix=@prefix@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include

--- a/pkgconfig/vamp.pc.in
+++ b/pkgconfig/vamp.pc.in
@@ -1,4 +1,4 @@
-prefix=%PREFIX%
+prefix=@prefix@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include


### PR DESCRIPTION
Use autoconf's variable substitution instead of sed for generating the .pc files.

Resolves #4